### PR TITLE
use multistage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,16 @@
-FROM golang:1.7.5-onbuild
+FROM golang:latest as builder
 MAINTAINER "Niek Palm <dev.npalm@gmail.com>"
+
+WORKDIR /go/src/app
+COPY main.go /go/src/app/main.go
+RUN go get -d -v github.com/gorilla/mux
+RUN go get -d -v github.com/samalba/dockerclient
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o app .
+
+
+FROM alpine:latest
+
+COPY --from=builder /go/src/app .
+CMD ["./app"]  
 
 EXPOSE 8080


### PR DESCRIPTION
The current image is over 600MB which is way to much.
Use multistage build to reduce image size to ~10MB

Before:
npalm/docker-discovery-agent   latest              258cc58cecae        11 months ago        684MB

After:
local/docker-discovery-agent   latest              3a99a10b0f65        About a minute ago   11.5MB